### PR TITLE
Add postgis support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,9 @@ GEM
     activerecord (7.0.3)
       activemodel (= 7.0.3)
       activesupport (= 7.0.3)
+    activerecord-postgis-adapter (8.0.1)
+      activerecord (~> 7.0.0)
+      rgeo-activerecord (~> 7.0.0)
     activestorage (7.0.3)
       actionpack (= 7.0.3)
       activejob (= 7.0.3)
@@ -109,6 +112,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     mongo (2.17.1)
       bson (>= 4.8.2, < 5.0.0)
@@ -132,6 +136,9 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     paint (2.2.1)
@@ -176,6 +183,10 @@ GEM
     redis (4.6.0)
     regexp_parser (2.4.0)
     rexml (3.2.5)
+    rgeo (2.4.0)
+    rgeo-activerecord (7.0.1)
+      activerecord (>= 5.0)
+      rgeo (>= 1.0.0)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -237,10 +248,12 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES
   activerecord (>= 6.0)
+  activerecord-postgis-adapter (~> 8.0.1)
   bunny (~> 2.19)
   devpack (~> 0.4.0)
   mongoid (~> 7.4)

--- a/lib/orchestration/docker_compose/app_service.rb
+++ b/lib/orchestration/docker_compose/app_service.rb
@@ -118,6 +118,7 @@ module Orchestration
       def database_url
         {
           'postgresql' => 'postgresql://postgres:password@database-local:5432/production',
+          'postgis' => 'postgis://postgres:password@database-local:5432/production',
           'mysql2' => 'mysql2://root:password@database-local:3306/production',
           'sqlite3' => 'sqlite3:db/production.sqlite3'
         }.fetch(DockerCompose::ComposeConfiguration.database_adapter_name, nil)

--- a/lib/orchestration/docker_compose/compose_configuration.rb
+++ b/lib/orchestration/docker_compose/compose_configuration.rb
@@ -6,6 +6,7 @@ module Orchestration
       def self.database_adapter_name
         return nil unless defined?(ActiveRecord)
         return 'postgresql' if defined?(::PG)
+        return 'postgis' if defined?(::POSTGIS)
         return 'mysql2' if defined?(::Mysql2)
         return 'sqlite3' if defined?(::SQLite3)
 
@@ -29,6 +30,7 @@ module Orchestration
 
         base = Orchestration::Services::Database::Adapters
         return base::Postgresql.new if defined?(::PG)
+        return base::Postgis.new if defined?(::PostGIS)
         return base::Mysql2.new if defined?(::Mysql2)
         return base::Sqlite3.new if defined?(::SQLite3)
 

--- a/lib/orchestration/docker_compose/compose_configuration.rb
+++ b/lib/orchestration/docker_compose/compose_configuration.rb
@@ -5,8 +5,8 @@ module Orchestration
     class ComposeConfiguration
       def self.database_adapter_name
         return nil unless defined?(ActiveRecord)
-        return 'postgresql' if defined?(::PG)
         return 'postgis' if defined?(::POSTGIS)
+        return 'postgresql' if defined?(::PG)
         return 'mysql2' if defined?(::Mysql2)
         return 'sqlite3' if defined?(::SQLite3)
 
@@ -29,8 +29,8 @@ module Orchestration
         return nil unless defined?(ActiveRecord)
 
         base = Orchestration::Services::Database::Adapters
-        return base::Postgresql.new if defined?(::PG)
         return base::Postgis.new if defined?(::PostGIS)
+        return base::Postgresql.new if defined?(::PG)
         return base::Mysql2.new if defined?(::Mysql2)
         return base::Sqlite3.new if defined?(::SQLite3)
 

--- a/lib/orchestration/services/database/adapters.rb
+++ b/lib/orchestration/services/database/adapters.rb
@@ -12,4 +12,5 @@ end
 require 'orchestration/services/database/adapters/adapter_base'
 require 'orchestration/services/database/adapters/mysql2'
 require 'orchestration/services/database/adapters/postgresql'
+require 'orchestration/services/database/adapters/postgis'
 require 'orchestration/services/database/adapters/sqlite3'

--- a/lib/orchestration/services/database/adapters/postgis.rb
+++ b/lib/orchestration/services/database/adapters/postgis.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Orchestration
+  module Services
+    module Database
+      module Adapters
+        class Postgis
+          include AdapterBase
+
+          def name
+            'postgis'
+          end
+
+          def image
+            'postgis/postgis'
+          end
+
+          def credentials
+            {
+              'username' => 'postgres',
+              'password' => 'password',
+              'database' => 'postgis'
+            }
+          end
+
+          def errors
+            [PG::ConnectionBad]
+          end
+
+          def default_port
+            5432
+          end
+
+          def environment
+            {
+              'POSTGRES_PASSWORD' => 'password',
+              'PGDATA' => data_dir
+            }
+          end
+
+          def data_dir
+            '/var/pgdata'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/orchestration/services/database/adapters/postgis.rb
+++ b/lib/orchestration/services/database/adapters/postgis.rb
@@ -12,14 +12,14 @@ module Orchestration
           end
 
           def image
-            'postgis/postgis'
+            'postgis/postgis:15-3.3'
           end
 
           def credentials
             {
               'username' => 'postgres',
               'password' => 'password',
-              'database' => 'postgis'
+              'database' => 'postgres'
             }
           end
 

--- a/lib/orchestration/services/database/configuration.rb
+++ b/lib/orchestration/services/database/configuration.rb
@@ -118,6 +118,7 @@ module Orchestration
             'mysql2' => adapters::Mysql2,
             'mysql' => adapters::Mysql2,
             'postgresql' => adapters::Postgresql,
+            'postgis' => adapters::Postgis,
             'sqlite3' => adapters::Sqlite3
           }.fetch(name).new(self)
         rescue KeyError

--- a/orchestration.gemspec
+++ b/orchestration.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'thor', '~> 1.2'
 
   spec.add_development_dependency 'activerecord', '>= 6.0'
+  spec.add_development_dependency 'activerecord-postgis-adapter', '~> 8.0.1'
   spec.add_development_dependency 'bunny', '~> 2.19'
   spec.add_development_dependency 'devpack', '~> 0.4.0'
   spec.add_development_dependency 'mongoid', '~> 7.4'

--- a/spec/orchestration/services/database/adapters/postgis_spec.rb
+++ b/spec/orchestration/services/database/adapters/postgis_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe Orchestration::Services::Database::Adapters::Postgis do
+  its(:name) { is_expected.to eql 'postgis' }
+  its(:image) { is_expected.to eql 'postgis/postgis:15-3.3' }
+  its(:credentials) do
+    is_expected.to eql(
+      'username' => 'postgres',
+      'password' => 'password',
+      'database' => 'postgres'
+    )
+  end
+
+  its(:errors) { is_expected.to eql [PG::ConnectionBad] }
+  its(:default_port) { is_expected.to eql 5432 }
+  its(:environment) do
+    is_expected.to eql(
+      'POSTGRES_PASSWORD' => 'password',
+      'PGDATA' => '/var/pgdata'
+    )
+  end
+
+  its(:data_dir) { is_expected.to eql '/var/pgdata' }
+end


### PR DESCRIPTION
[Postgis is a ](https://postgis.net/) spatial database extender for [PostgreSQL](https://postgresql.org/) object-relational database. It adds support for geographic objects allowing location queries to be run in SQL.

to support postgis databases, I added it as an adaptor, added specs and made some other amendments